### PR TITLE
Add a new exception for forbidden login

### DIFF
--- a/scratchconnect/Exceptions.py
+++ b/scratchconnect/Exceptions.py
@@ -45,3 +45,8 @@ class InvalidForumTopic(Exception):
     Raised when the forum topic is invalid
     """
     pass
+
+class ForbiddenLogin(Exception):
+    """
+    Raised when Scratch sends a 403 Forbidden Status Code while logging in
+    """

--- a/scratchconnect/ScratchConnect.py
+++ b/scratchconnect/ScratchConnect.py
@@ -44,6 +44,12 @@ class ScratchConnect:
         data = json.dumps({"username": self.username, "password": self.password})
         request = requests.post(f"{_login}", data=data, headers=headers)
         try:
+            request.json()
+        except Exception:
+            # Login did not fail, but Scratch is preventing login
+            if request.status_code == 403:
+                raise Exceptions.ForbiddenLogin("Scratch is not letting you login from this device.\nTry again later or from another device.")
+        try:
             self.session_id = re.search('"(.*)"', request.headers["Set-Cookie"]).group()
             self.token = request.json()[0]["token"]
         except AttributeError:


### PR DESCRIPTION
On the forum topic it was reported that Scratch sometimes blocks particular logins, so this adds a new exception to let the user know what happened.

### Before
It said that your username or password is incorrect

### Now
It says that Scratch is not letting you login from this device.

#### Please note:
This hasn't been tested, so please only merge if you test it out. Since you were busy I decided to implement this as a very basic solution.